### PR TITLE
Fix user-agent at authData request

### DIFF
--- a/xtream-codes.go
+++ b/xtream-codes.go
@@ -82,6 +82,7 @@ func NewClientWithContext(ctx context.Context, username, password, baseURL strin
 
 // NewClientWithUserAgent returns an initialized XtreamClient with the given values.
 func NewClientWithUserAgent(ctx context.Context, username, password, baseURL, userAgent string) (*XtreamClient, error) {
+	defaultUserAgent = userAgent
 	c, err := NewClient(username, password, baseURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
At NewClientWithUserAgent change User-Agent before initialized XtreamClient or it will do a request for authData with the User-agent "go.xstream-codes (Go-http-client/1.1)" instead of the userAgent parameter.